### PR TITLE
Executes performance tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - PGUSER=postgres
 before_script:
   - psql -c 'create database message_bus_test;' -U postgres
+script: rake ci
 services:
   - redis-server
   - postgresql

--- a/Rakefile
+++ b/Rakefile
@@ -67,3 +67,5 @@ end
 
 desc "Run all tests, link checks and confirms documentation compiles without error"
 task default: [:spec, :rubocop, :test_doc]
+
+task ci: [:default, :performance]


### PR DESCRIPTION
I'd like to revisit this in isolation. It was unclear in https://github.com/SamSaffron/message_bus/pull/190 if the objection was to execution in the default task (which perhaps people run when working on message_bus) or execution in CI.

CI is the quietest most stable environment we have available in which to execute these. Development hardware is noisy, and we have no other environment readily available.

Sam mentioned the possibility of using https://rubybench.org/, but from that site I found no evidence that it is an option at this time.