### PR TITLE
FIX: Don't publish message to intersection of `user_ids` and `group_ids`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Unreleasd
   - Drop support for Ruby 2.3
+  - FIX: Don't publish message to intersection of `user_ids` and `group_ids`
 
 26-03-2020
 

--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -128,15 +128,26 @@ class MessageBus::Client
   # @return [Boolean] whether or not the client has permission to receive the
   #   passed message
   def allowed?(msg)
-    allowed = !msg.user_ids || msg.user_ids.include?(self.user_id)
-    allowed &&= !msg.client_ids || msg.client_ids.include?(self.client_id)
-    allowed && (
-      msg.group_ids.nil? ||
-      msg.group_ids.length == 0 ||
-      (
-        msg.group_ids - self.group_ids
+    client_allowed = !msg.client_ids || msg.client_ids.length == 0 || msg.client_ids.include?(self.client_id)
+
+    user_allowed = false
+    group_allowed = false
+
+    # this is an inconsistency we should fix anyway, publishing `user_ids: nil` should work same as groups
+    has_users = msg.user_ids && msg.user_ids.length > 0
+    has_groups = msg.group_ids && msg.group_ids.length > 0
+
+    if has_users
+      user_allowed = msg.user_ids.include?(self.user_id)
+    end
+
+    if has_groups
+      group_allowed = (
+        msg.group_ids - (self.group_ids || [])
       ).length < msg.group_ids.length
-    )
+    end
+
+    client_allowed && (user_allowed || group_allowed || (!has_users && !has_groups))
   end
 
   # @return [Array<MessageBus::Message>] the set of messages the client is due


### PR DESCRIPTION
The original design intent was to always publish messages to clients
that are either in `user_ids` and `group_ids`. However, there is a long
standing bug where we only published to the intersection of `user_ids`
and `group_ids` which this commit seeks to resolve.