### PR TITLE
Update Changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-- Unreleased
+- Version 3.3.0
 
    - FEATURE: `MessageBus.base_route=` to alter the route that message bus will listen on.
 


### PR DESCRIPTION
https://github.com/discourse/message_bus/commit/a5dc2338e0e36d49c4c81864609ef8726bbee5e0 forgot to update the changelog and there also doesn't seem to be a release version tag.