### PR TITLE
FEATURE: Warn when not using a number for lastId

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+- Unreleased
+
+  - BREAKING CHANGE: In the JavaScript client throw when when lastId is given but is not a number.
+
 09-06-2020
 
 - Version 3.3.1

--- a/README.md
+++ b/README.md
@@ -304,6 +304,11 @@ MessageBus.subscribe("/channel", function(data){
 MessageBus.subscribe("/channel", function(data){
   // data shipped from server
 }, -3);
+
+// you will get the entire backlog
+MessageBus.subscribe("/channel", function(data){
+  // data shipped from server
+}, 0);
 ```
 
 #### JavaScript Client settings

--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -484,13 +484,16 @@
     // -1 will subscribe to all new messages
     // -2 will recieve last message + all new messages
     // -3 will recieve last 2 messages + all new messages
+    // if undefined will default to -1
     subscribe: function(channel, func, lastId) {
       if (!started && !stopped) {
         me.start();
       }
 
-      if (typeof lastId !== "number") {
+      if (lastId === null || typeof lastId === "undefined") {
         lastId = -1;
+      } else if (typeof lastId !== "number") {
+        throw "lastId has type " + typeof lastId + " but a number was expected.";
       }
 
       if (typeof channel !== "string") {


### PR DESCRIPTION
By mistake we set `lastId = "0"` which was silently changed to `-1` which took longer than it should have done to track down.

As an aside:

I tried to add a JS spec but I got 
```
jasmine server started
Auto configuration failed
140219735228032:error:25066067:DSO support routines:DLFCN_LOAD:could not load the shared library:dso_dlfcn.c:185:filename(libssl_conf.so): libssl_conf.so: cannot open shared object file: No such file or directory
140219735228032:error:25070067:DSO support routines:DSO_load:could not load the shared library:dso_lib.c:244:
140219735228032:error:0E07506E:configuration file routines:MODULE_LOAD_DSO:error loading dso:conf_mod.c:285:module=ssl_conf, path=ssl_conf
140219735228032:error:0E076071:configuration file routines:MODULE_RUN:unknown module name:conf_mod.c:222:module=ssl_conf
```
on my machine and when using docker.  I'm guessing this is something to do with https://github.com/bazelbuild/rules_closure/pull/353, maybe it is worth looking at headless broswer alternatives to phantomjs?