### PR TITLE
FEATURE: Drop support for ruby 2.3

### DIFF
--- a/message_bus.gemspec
+++ b/message_bus.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.name          = "message_bus"
   gem.require_paths = ["lib"]
   gem.version       = MessageBus::VERSION
-  gem.required_ruby_version = ">= 2.3.0"
+  gem.required_ruby_version = ">= 2.4.0"
   gem.add_runtime_dependency 'rack', '>= 1.1.3'
   gem.add_development_dependency 'redis'
   gem.add_development_dependency 'pg'


### PR DESCRIPTION
Ruby 2.3 is EOL since March 2019 and recent versions of rubocop no longer supports it.