### PR TITLE
Permit CORS preflight caching

### DIFF
--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -225,7 +225,6 @@
         "/poll" +
         (!longPoll ? "?dlp=t" : ""),
       data: data,
-      cache: false,
       async: true,
       dataType: dataType,
       type: "POST",


### PR DESCRIPTION
With this argument, an incrementing query parameter is added to the URL, which prevents a browser from utilising the CORS preflight cache.

The jQuery documentation states:

> If set to false, it will force requested pages not to be cached by the browser. Note: Setting cache to false will only work correctly with HEAD and GET requests. It works by appending "_={timestamp}" to the GET parameters. The parameter is not needed for other types of requests, except in IE8 when a POST is made to a URL that has already been requested by a GET.

The message_bus middleware implementation [sets the correct headers to prevent the browser caching the actual response](https://github.com/discourse/message_bus/blob/master/lib/message_bus/rack/middleware.rb#L115-L118) so it is unnecessary for the JavaScript client to also force a cache miss in a way that doubles request throughput in a use-case which requires CORS.

Fixes #245