### PR TITLE
Remove cache busting implementation from AJAX shim

### DIFF
--- a/assets/message-bus-ajax.js
+++ b/assets/message-bus-ajax.js
@@ -12,8 +12,7 @@
     var XHRImpl = (global.MessageBus && global.MessageBus.xhrImplementation) || global.XMLHttpRequest;
     var xhr = new XHRImpl();
     xhr.dataType = options.dataType;
-    var url = options.url;
-    xhr.open('POST', url);
+    xhr.open('POST', options.url);
     for (var name in options.headers){
       xhr.setRequestHeader(name, options.headers[name]);
     }

--- a/assets/message-bus-ajax.js
+++ b/assets/message-bus-ajax.js
@@ -8,16 +8,11 @@
       throw new Error("MessageBus must be loaded before the ajax adapter");
   }
 
-  var cacheBuster =  Math.random() * 10000 | 0;
-
   global.MessageBus.ajax = function(options){
     var XHRImpl = (global.MessageBus && global.MessageBus.xhrImplementation) || global.XMLHttpRequest;
     var xhr = new XHRImpl();
     xhr.dataType = options.dataType;
     var url = options.url;
-    if (!options.cache){
-      url += ((-1 == url.indexOf('?')) ? '?' : '&') + '_=' + (cacheBuster++)
-    }
     xhr.open('POST', url);
     for (var name in options.headers){
       xhr.setRequestHeader(name, options.headers[name]);


### PR DESCRIPTION
#246 intended to prevent this from happening, but we only tested with jQuery, whose default for this value is `true`. Our shim for `$.ajax` defaults to `false`, so in that context the desired change didn't take effect. This shim is supposed to be lightweight to address only MessageBus' requirements, so here we remove support for the now unused `cache` option entirely, rather than flipping the default.