### PR TITLE
CI: Experiment with a Redis container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,13 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: "redis:${{ matrix.redis }}-alpine" # Docker Hub image tag
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       matrix:
         ruby: ["3.0", "2.7", "2.6"]
-        redis: ["5.x", "6.x"]
+        redis: ["5.0", "6.0", "6.2"]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
@@ -36,10 +39,6 @@ jobs:
           bundler-cache: true # 'bundle install' and cache
       - name: Create Database
         run: |
-          createdb message_bus_test
-      - name: Setup redis
-        uses: shogo82148/actions-setup-redis@v1
-        with:
-          redis-version: ${{ matrix.redis }}
+          createdb message_bus_test          
       - name: Tests
         run: bundle exec rake


### PR DESCRIPTION
Service containers run their service as Docker containers, nothing special about them. This is a test shot to see if we can use such a "Service" setup, instead of a "Step" doing the installation.

---

## Learnings

First issue: `EEW, [2021-10-21T06:52:54.564837 #3828]  WARN -- : Error connecting to Redis on 127.0.0.1:6379 (Errno::ECONNREFUSED) subscribe failed, reconnecting in 1 second. Call stack /home/runner/work/message_bus/message_bus/vendor/bundle/ruby/3.0.0/gems/redis-4.5.1/lib/redis/client.rb:398:in `rescue in establish_connection'`

TODO: Find the connection string value and set it in an env.