### PR TITLE
FIX: prevent clobbering the session

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Unreleased
+
+  - FIX: Prevent simple polling from clobbering the session
+
 31-05-2021
 
 - Version 3.3.6

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -66,6 +66,12 @@ class MessageBus::Rack::Middleware
   private
 
   def handle_request(env)
+    # Prevent simple polling from clobbering the session
+    # See: https://github.com/discourse/message_bus/issues/257
+    if (rack_session_options = env[Rack::RACK_SESSION_OPTIONS])
+      rack_session_options[:skip] = true
+    end
+
     # special debug/test route
     if @bus.allow_broadcast? && env['PATH_INFO'] == @broadcast_route
       parsed = Rack::Request.new(env)

--- a/spec/lib/message_bus/rack/middleware_spec.rb
+++ b/spec/lib/message_bus/rack/middleware_spec.rb
@@ -414,6 +414,11 @@ describe MessageBus::Rack::Middleware do
       JSON.parse(last_response.body).first["data"].must_equal('json' => true)
     end
 
+    it "should tell Rack to skip committing the session" do
+      post "/message-bus/1234", {}, {"rack.session.options" => {}}
+      last_request.env["rack.session.options"][:skip].must_equal true
+    end
+
     describe "on_middleware_error handling" do
       it "allows error handling of middleware failures" do
         @bus.on_middleware_error do |_env, err|


### PR DESCRIPTION
Simple polling was letting Rack commit the session, clobbering values
set by other means. Fix by telling Rack to skip committing the session.

Fixes #257