### PR TITLE
Handle Client#add failure on PostgreSQL

### DIFF
--- a/lib/message_bus/backends/postgres.rb
+++ b/lib/message_bus/backends/postgres.rb
@@ -277,7 +277,7 @@ module MessageBus
         msg = MessageBus::Message.new backlog_id, backlog_id, channel, data
         payload = msg.encode
         c.publish postgresql_channel_name, payload
-        if backlog_id % clear_every == 0
+        if backlog_id && backlog_id % clear_every == 0
           max_backlog_size = (opts && opts[:max_backlog_size]) || self.max_backlog_size
           max_backlog_age = (opts && opts[:max_backlog_age]) || self.max_backlog_age
           c.clear_global_backlog(backlog_id, @max_global_backlog_size)


### PR DESCRIPTION
Client#hold can silently swallow errors and return nil for
PG::ConnectionBad and PG::UnableToSend exceptions.  If that
happens during #add, don't try to check whether to clear the
backlog, which would raise a NoMethodError.

Should work around the following CI failure:

```
NoMethodError: undefined method `%' for nil:NilClass
    /home/runner/work/message_bus/message_bus/lib/message_bus/backends/postgres.rb:280:in `publish'
    spec/lib/message_bus/backend_spec.rb:131:in `block (2 levels) in <top (required)>'
```