### PR TITLE
Make message-bus-ajax use x-www-form-urlencoded Content-Type

### DIFF
--- a/assets/message-bus-ajax.js
+++ b/assets/message-bus-ajax.js
@@ -16,7 +16,7 @@
     for (var name in options.headers){
       xhr.setRequestHeader(name, options.headers[name]);
     }
-    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     if (options.messageBus.chunked){
       options.messageBus.onProgressListener(xhr);
     }
@@ -31,7 +31,7 @@
         options.complete();
       }
     }
-    xhr.send(JSON.stringify(options.data));
+    xhr.send(new URLSearchParams(options.data).toString());
     return xhr;
   };
 


### PR DESCRIPTION
I tried switching out jQuery for message-bus-ajax.js and it
didn't work.  After extensive debugging, I found that while
jQuery.ajax uses application/x-www-form-urlencoded,
message-bus-ajax.js was using JSON.  That broke my application,
which doesn't automatically parse JSON requests (it uses
roda-message_bus internally, which looks at the request body
before passing control to message_bus).  I think requests made by
message-bus-ajax.js should mirror the requests that jQuery.ajax
would use, so this switches message-bus-ajax.js to use
application/x-www-form-urlencoded.

This uses URLSearchParams to serialize the data.  Support for it
is pretty good (> 96%, about the same as CSS Grid).  If you want
to support a browser doesn't support URLSearchParams, you are
probably using jQuery anyway to handle cross-browser differences,
so you wouldn't be using message-bus-ajax.js.

CC @nathanstitt