### PR TITLE
Combine 5 socket write calls into 1

### DIFF
--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -283,7 +283,11 @@ class MessageBus::Client
     @bus.logger.debug "Delivering messages #{data} to client #{client_id} for user #{user_id}"
     if @io
       write_headers
-      @io.write(CONTENT_LENGTH.dup << data.bytes.to_a.length << NEWLINE << NEWLINE << data)
+      @io.write(CONTENT_LENGTH)
+      @io.write(data.bytes.to_a.length)
+      @io.write(NEWLINE)
+      @io.write(NEWLINE)
+      @io.write(data)
       @io.close
       @io = nil
     else

--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -275,11 +275,7 @@ class MessageBus::Client
       @async_response << postfix
       @async_response << NEWLINE
     else
-      @io.write(chunk_length.to_s(16))
-      @io.write(NEWLINE)
-      @io.write(data)
-      @io.write(postfix)
-      @io.write(NEWLINE)
+      @io.write(chunk_length.to_s(16) << NEWLINE << data << postfix << NEWLINE)
     end
   end
 
@@ -287,11 +283,7 @@ class MessageBus::Client
     @bus.logger.debug "Delivering messages #{data} to client #{client_id} for user #{user_id}"
     if @io
       write_headers
-      @io.write(CONTENT_LENGTH)
-      @io.write(data.bytes.to_a.length)
-      @io.write(NEWLINE)
-      @io.write(NEWLINE)
-      @io.write(data)
+      @io.write(CONTENT_LENGTH.dup << data.bytes.to_a.length << NEWLINE << NEWLINE << data)
       @io.close
       @io = nil
     else


### PR DESCRIPTION
This greatly improves reliability and performance at near-idle
in my testing.  Testing with a simple chat app with two clients,
with previous behavior of 5 separate write calls, I would often
get delays up to about 30 seconds between publishing something
in message_bus and having the client fully receive it.  Combining
these calls into a single call makes it almost instantaneous.

This causes 1 extra string allocation per chunk, but since it
saves 4 method calls, it's probably a net win when data being
sent is small, though I didn't benchmark it.  However, if the
data being sent is very large, this could potentially introduce
significant overhead.

I'm not sure this matters in the write_and_close case, since
there is a call to close immediately following it, but in
write_chunk case, it's definitely important.  You want to
ensure the chunk delimiter is included in the packet containing
the data, and not split into a separate packet that may be sent
later.