### PR TITLE
DEV: Fix logger usage in backend specs

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+require 'logger'
+
 def wait_for(timeout_milliseconds = 2000)
   timeout = (timeout_milliseconds + 0.0) / 1000
   finish = Time.now + timeout
@@ -9,7 +12,11 @@ def wait_for(timeout_milliseconds = 2000)
 end
 
 def test_config_for_backend(backend)
-  config = { backend: backend }
+  config = {
+    backend: backend,
+    logger: Logger.new(IO::NULL),
+  }
+
   case backend
   when :redis
     config[:url] = ENV['REDISURL']


### PR DESCRIPTION
Fixes errors like:

```
#<Thread:0x000056404956cd60 spec/lib/message_bus/backend_spec.rb:391 run> terminated with exception (report_on_exception is true):
/home/runner/work/message_bus/message_bus/lib/message_bus/backends/postgres.rb:391:in `rescue in global_subscribe': private method `warn' called for nil:NilClass (NoMethodError)
	from /home/runner/work/message_bus/message_bus/lib/message_bus/backends/postgres.rb:346:in `global_subscribe'
	from /home/runner/work/message_bus/message_bus/lib/message_bus/backends/postgres.rb:329:in `subscribe'
	from spec/lib/message_bus/backend_spec.rb:392:in `block (3 levels) in <top (required)>'
```