### PR TITLE
DEV: Fix an incorrect Rails check

### DIFF
--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -275,7 +275,7 @@ module MessageBus::Implementation
   #   set, defaults to false unless we're in Rails test or development mode.
   def allow_broadcast?
     @config[:allow_broadcast] ||=
-      if defined? ::Rails
+      if defined? ::Rails.env
         ::Rails.env.test? || ::Rails.env.development?
       else
         false


### PR DESCRIPTION
The check was incorrect, since `Rails` module always exists in specs because of MiniTest's `Rails::TestUnitReporter` and `Rails::TestUnit`.