### PR TITLE
Revert "Remove files that no longer exist."

### DIFF
--- a/lib/message_bus/version.rb
+++ b/lib/message_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessageBus
-  VERSION = "3.3.7"
+  VERSION = "3.3.8"
 end

--- a/message_bus.gemspec
+++ b/message_bus.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{}
   gem.homepage      = "https://github.com/discourse/message_bus"
   gem.license       = "MIT"
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = `git ls-files`.split($\) +
+                      ["vendor/assets/javascripts/message-bus.js", "vendor/assets/javascripts/message-bus-ajax.js"]
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "message_bus"


### PR DESCRIPTION
This reverts commit 2662d64b3d80dce380d67f46b4907b738f353095.

1. these files do exist, see: https://github.com/discourse/message_bus/blob/main/Rakefile#L23
2. they're not included by `git ls-files`, see: https://github.com/discourse/message_bus/blob/main/vendor/assets/javascripts/.gitignore