### PR TITLE
DEV: Fix ruby warnings

### DIFF
--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -41,6 +41,10 @@ module MessageBus::Implementation
   def initialize
     @config = {}
     @mutex = Synchronizer.new
+    @off = false
+    @destroyed = false
+    @timer_thread = nil
+    @subscriber_thread = nil
   end
 
   # @param [Boolean] val whether or not to cache static assets for the diagnostics pages

--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -46,6 +46,9 @@ class MessageBus::Client
     @bus = opts[:message_bus] || MessageBus
     @subscriptions = {}
     @chunks_sent = 0
+    @async_response = nil
+    @io = nil
+    @wrote_headers = false
   end
 
   # @yield executed with a lock on the Client instance

--- a/lib/message_bus/distributed_cache.rb
+++ b/lib/message_bus/distributed_cache.rb
@@ -22,6 +22,7 @@ module MessageBus
         @lock = Mutex.new
         @message_bus = message_bus || MessageBus
         @publish_queue_in_memory = publish_queue_in_memory
+        @app_version = nil
       end
 
       def subscribers

--- a/lib/message_bus/rack/thin_ext.rb
+++ b/lib/message_bus/rack/thin_ext.rb
@@ -9,6 +9,7 @@ module Thin
 
       def initialize
         @queue = []
+        @body_callback = nil
       end
 
       def call(body)

--- a/spec/lib/fake_async_middleware.rb
+++ b/spec/lib/fake_async_middleware.rb
@@ -7,6 +7,7 @@ class FakeAsyncMiddleware
     @simulate_thin_async = false
     @simulate_hijack = false
     @in_async = false
+    @allow_chunked = false
   end
 
   def app

--- a/spec/lib/message_bus/connection_manager_spec.rb
+++ b/spec/lib/message_bus/connection_manager_spec.rb
@@ -6,6 +6,10 @@ require 'message_bus'
 class FakeAsync
   attr_accessor :cleanup_timer
 
+  def initialize
+    @sent = nil
+  end
+
   def <<(val)
     sleep 0.01 # simulate IO
     @sent ||= +""


### PR DESCRIPTION
100% clean output when running with `--verbose` flag.