### PR TITLE
FIX: Stop various thread/pg connection leaks

### DIFF
--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -537,6 +537,7 @@ module MessageBus::Implementation
     return if @destroyed
 
     reliable_pub_sub.global_unsubscribe
+    reliable_pub_sub.destroy
 
     @mutex.synchronize do
       return if @destroyed

--- a/lib/message_bus/backends/base.rb
+++ b/lib/message_bus/backends/base.rb
@@ -84,6 +84,11 @@ module MessageBus
         raise ConcreteClassMustImplementError
       end
 
+      # Closes all open connections to the storage.
+      def destroy
+        raise ConcreteClassMustImplementError
+      end
+
       # Deletes all backlogs and their data. Does not delete non-backlog data that message_bus may persist, depending on the concrete backend implementation. Use with extreme caution.
       # @abstract
       def expire_all_backlogs!

--- a/lib/message_bus/backends/memory.rb
+++ b/lib/message_bus/backends/memory.rb
@@ -212,6 +212,12 @@ module MessageBus
         client.reset!
       end
 
+      # No-op; this backend doesn't maintain any storage connections.
+      # (see Base#destroy)
+      def destroy
+        nil
+      end
+
       # (see Base#expire_all_backlogs!)
       def expire_all_backlogs!
         client.expire_all_backlogs!

--- a/lib/message_bus/backends/postgres.rb
+++ b/lib/message_bus/backends/postgres.rb
@@ -412,9 +412,7 @@ module MessageBus
       private
 
       def client
-        @mutex.synchronize do
-          @client ||= Client.new(@config)
-        end
+        @client || @mutex.synchronize { @client ||= Client.new(@config) }
       end
 
       def postgresql_channel_name

--- a/lib/message_bus/backends/postgres.rb
+++ b/lib/message_bus/backends/postgres.rb
@@ -86,10 +86,12 @@ module MessageBus
           hold { |conn| exec_prepared(conn, 'get_message', [channel, id]) { |r| r.getvalue(0, 0) } }
         end
 
-        def reconnect
+        def after_fork
           sync do
-            @listening_on.clear
+            @pid = Process.pid
+            INHERITED_CONNECTIONS.concat(@available)
             @available.clear
+            @listening_on.clear
           end
         end
 
@@ -98,6 +100,13 @@ module MessageBus
           hold do |conn|
             conn.exec 'DROP TABLE IF EXISTS message_bus'
             create_table(conn)
+          end
+        end
+
+        def destroy
+          sync do
+            @available.each(&:close)
+            @available.clear
           end
         end
 
@@ -174,11 +183,7 @@ module MessageBus
         def hold
           current_pid = Process.pid
           if current_pid != @pid
-            @pid = current_pid
-            sync do
-              INHERITED_CONNECTIONS.concat(@available)
-              @available.clear
-            end
+            after_fork
           end
 
           if conn = sync { @allocated[Thread.current] }
@@ -253,17 +258,23 @@ module MessageBus
         # after 7 days inactive backlogs will be removed
         @max_backlog_age = 604800
         @clear_every = config[:clear_every] || 1
+        @mutex = Mutex.new
       end
 
       # Reconnects to Postgres; used after a process fork, typically triggered by a forking webserver
       # @see Base#after_fork
       def after_fork
-        client.reconnect
+        client.after_fork
       end
 
       # (see Base#reset!)
       def reset!
         client.reset!
+      end
+
+      # (see Base#destroy)
+      def destroy
+        client.destroy
       end
 
       # (see Base#expire_all_backlogs!)
@@ -401,11 +412,9 @@ module MessageBus
       private
 
       def client
-        @client ||= new_connection
-      end
-
-      def new_connection
-        Client.new(@config)
+        @mutex.synchronize do
+          @client ||= Client.new(@config)
+        end
       end
 
       def postgresql_channel_name

--- a/lib/message_bus/backends/redis.rb
+++ b/lib/message_bus/backends/redis.rb
@@ -65,7 +65,7 @@ module MessageBus
       # Reconnects to Redis; used after a process fork, typically triggered by a forking webserver
       # @see Base#after_fork
       def after_fork
-        pub_redis.disconnect!
+        @pub_redis&.disconnect!
       end
 
       # (see Base#reset!)
@@ -73,6 +73,11 @@ module MessageBus
         pub_redis.keys("__mb_*").each do |k|
           pub_redis.del k
         end
+      end
+
+      # (see Base#destroy)
+      def destroy
+        @pub_redis&.disconnect!
       end
 
       # Deletes all backlogs and their data. Does not delete ID pointers, so new publications will get IDs that continue from the last publication before the expiry. Use with extreme caution.

--- a/spec/lib/message_bus/backend_spec.rb
+++ b/spec/lib/message_bus/backend_spec.rb
@@ -10,6 +10,7 @@ describe PUB_SUB_CLASS do
 
   after do
     @bus.reset!
+    @bus.destroy
   end
 
   describe "API parity" do

--- a/spec/lib/message_bus/client_spec.rb
+++ b/spec/lib/message_bus/client_spec.rb
@@ -16,6 +16,7 @@ describe MessageBus::Client do
     end
 
     after do
+      @client.close
       @bus.reset!
       @bus.destroy
     end

--- a/spec/lib/message_bus/rack/middleware_spec.rb
+++ b/spec/lib/message_bus/rack/middleware_spec.rb
@@ -83,7 +83,7 @@ describe MessageBus::Rack::Middleware do
         { "FOO" => "BAR" }
       end
 
-      Thread.new do
+      t = Thread.new do
         wait_for(2000) { middleware.in_async? }
         bus.publish "/foo", "םוֹלשָׁ"
       end
@@ -96,6 +96,7 @@ describe MessageBus::Rack::Middleware do
       parsed[0]["data"].must_equal "םוֹלשָׁ"
 
       last_response.headers["FOO"].must_equal "BAR"
+      t.join
     end
 
     it "should timeout within its alloted slot" do

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -23,7 +23,8 @@ describe MessageBus do
     @bus.off?.must_equal true
   end
 
-  it "can call destroy twice" do
+  it "can call destroy multiple times" do
+    @bus.destroy
     @bus.destroy
     @bus.destroy
   end


### PR DESCRIPTION
* Close postgres connections when destroying the parent bus (we've been leaking connections which led to test failures and timeouts)
* Create `Postgres::Client` in a mutex (initializing a bus in a multi-threaded env could result in multiple instances)
* Close/destroy objects after each spec; cleanly stop processes and threads