### PR TITLE
DEV: Rename reliable_pub_sub to backend_instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,17 +400,17 @@ The redis client message_bus uses is [redis-rb](https://github.com/redis/redis-r
 
 Out of the box Redis keeps track of 2000 messages in the global backlog and 1000 messages in a per-channel backlog. Per-channel backlogs get cleared automatically after 7 days of inactivity.
 
-This is configurable via accessors on the ReliablePubSub instance.
+This is configurable via accessors on the Backend instance.
 
 ```ruby
 # only store 100 messages per channel
-MessageBus.reliable_pub_sub.max_backlog_size = 100
+MessageBus.backend_instance.max_backlog_size = 100
 
 # only store 100 global messages
-MessageBus.reliable_pub_sub.max_global_backlog_size = 100
+MessageBus.backend_instance.max_global_backlog_size = 100
 
 # flush per-channel backlog after 100 seconds of inactivity
-MessageBus.reliable_pub_sub.max_backlog_age = 100
+MessageBus.backend_instance.max_backlog_age = 100
 ```
 
 ### PostgreSQL

--- a/spec/lib/message_bus/backend_spec.rb
+++ b/spec/lib/message_bus/backend_spec.rb
@@ -3,9 +3,9 @@
 require_relative '../../spec_helper'
 require 'message_bus'
 
-describe PUB_SUB_CLASS do
+describe BACKEND_CLASS do
   before do
-    @bus = PUB_SUB_CLASS.new(test_config_for_backend(CURRENT_BACKEND))
+    @bus = BACKEND_CLASS.new(test_config_for_backend(CURRENT_BACKEND))
   end
 
   after do
@@ -30,7 +30,7 @@ describe PUB_SUB_CLASS do
   end
 
   it "should initialize with max_backlog_size" do
-    PUB_SUB_CLASS.new({}, 2000).max_backlog_size.must_equal 2000
+    BACKEND_CLASS.new({}, 2000).max_backlog_size.must_equal 2000
   end
 
   it "should truncate channels correctly" do

--- a/spec/lib/message_bus/multi_process_spec.rb
+++ b/spec/lib/message_bus/multi_process_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../../spec_helper'
 require 'message_bus'
 
-describe PUB_SUB_CLASS do
+describe BACKEND_CLASS do
   def self.error!
     @error = true
   end
@@ -13,7 +13,7 @@ describe PUB_SUB_CLASS do
   end
 
   def new_bus
-    PUB_SUB_CLASS.new(test_config_for_backend(CURRENT_BACKEND).merge(db: 10))
+    BACKEND_CLASS.new(test_config_for_backend(CURRENT_BACKEND).merge(db: 10))
   end
 
   def work_it

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -107,7 +107,7 @@ describe MessageBus do
     @bus.publish("/chuck", norris: true)
     @bus.publish("/chuck", norris: true)
 
-    @bus.reliable_pub_sub.reset!
+    @bus.backend_instance.reset!
 
     @bus.publish("/chuck", yeager: true)
 
@@ -125,7 +125,7 @@ describe MessageBus do
     @bus.publish("/chuck", norris: true)
     @bus.publish("/chuck", norris: true)
 
-    @bus.reliable_pub_sub.expire_all_backlogs!
+    @bus.backend_instance.expire_all_backlogs!
 
     @bus.publish("/chuck", yeager: true)
 

--- a/spec/performance/publish.rb
+++ b/spec/performance/publish.rb
@@ -32,8 +32,8 @@ benchmark_subscription_no_trimming = lambda do |bm, backend|
   bus = MessageBus::Instance.new
   bus.configure(test_config_for_backend(backend))
 
-  bus.reliable_pub_sub.max_backlog_size = iterations
-  bus.reliable_pub_sub.max_global_backlog_size = iterations
+  bus.backend_instance.max_backlog_size = iterations
+  bus.backend_instance.max_global_backlog_size = iterations
 
   messages_received = 0
   bus.after_fork
@@ -58,8 +58,8 @@ benchmark_subscription_with_trimming = lambda do |bm, backend|
   bus = MessageBus::Instance.new
   bus.configure(test_config_for_backend(backend))
 
-  bus.reliable_pub_sub.max_backlog_size = (iterations / 10)
-  bus.reliable_pub_sub.max_global_backlog_size = (iterations / 10)
+  bus.backend_instance.max_backlog_size = (iterations / 10)
+  bus.backend_instance.max_global_backlog_size = (iterations / 10)
 
   messages_received = 0
   bus.after_fork

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ require_relative "helpers"
 CURRENT_BACKEND = (ENV['MESSAGE_BUS_BACKEND'] || :redis).to_sym
 
 require "message_bus/backends/#{CURRENT_BACKEND}"
-PUB_SUB_CLASS = MessageBus::BACKENDS.fetch(CURRENT_BACKEND)
+BACKEND_CLASS = MessageBus::BACKENDS.fetch(CURRENT_BACKEND)
 
 puts "Running with backend: #{CURRENT_BACKEND}"
 


### PR DESCRIPTION
It's already referred to as backend in most places, and the classes inherit from Backend::Base, so this makes the naming consistent.

Ideally I'd prefer `MessageBus#backend` instead of `MessageBus#backend_instance`, but `#backend` already exists so we can't rename both at the same time without breaking back-compatibility.