### PR TITLE
DEV: Remove `yarn publish` from `rake release`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -101,7 +101,3 @@ end
 
 desc "Run all tests, link checks and confirms documentation compiles without error"
 task default: [:spec, :rubocop, :test_doc]
-
-Rake::Task['release'].enhance do
-  sh "yarn publish"
-end


### PR DESCRIPTION
CI workflow does that now in a separate step.