### PR TITLE
FEATURE: remove self kill on keepalive expiry

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Unreleased
+
+- Version 3.3.9
+
+   - FEATURE: remove "suicide" feature from message_bus - (message_bus used to terminate process when keepalive exceeded)
+
 20-12-2021
 
 - Version 3.3.8

--- a/README.md
+++ b/README.md
@@ -392,6 +392,16 @@ headers|{}|Extra headers to be include with requests. Properties and values of o
 
 message_bus can be configured to use one of several available storage backends, and each has its own configuration options.
 
+### Keepalive
+
+To ensure correct operation of message_bus, every 60 seconds a message is broadcast to itself. If for any reason the message is not consumed by the same process within 3 keepalive intervals a warning log message is raised.
+
+To control keepalive interval use
+
+```ruby
+MessageBus.configure(keepalive_interval: 60)
+```
+
 ### Redis
 
 message_bus supports using Redis as a storage backend, and you can configure message_bus to use redis in `config/initializers/message_bus.rb`, like so:


### PR DESCRIPTION
Previously if message bus stalled for 3 * keepalive (default 60 seconds)
it would terminate itself.

This causes pathological issues when a bus is in readonly mode and is a
very unsafe default.

The reasoning for the keepalive check was to ensure the bus it always
functioning, the remediation was deescalated to a log warning.
