### PR TITLE
CI: Add Ruby 3.1 to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, '3.0', 3.1]
         redis: [5, 6]
 
     services:


### PR DESCRIPTION
This also avoids a YAML snag in that 3.0 is stringified to "3".