### PR TITLE
gemspec: Drop unused directives

### DIFF
--- a/message_bus.gemspec
+++ b/message_bus.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
   gem.files         = `git ls-files`.split($\) +
                       ["vendor/assets/javascripts/message-bus.js", "vendor/assets/javascripts/message-bus-ajax.js"]
-  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "message_bus"
   gem.require_paths = ["lib"]
   gem.version       = MessageBus::VERSION


### PR DESCRIPTION
This PR cleans up two unused directives in the gemspec.

- RubyGems.org no longer uses test_files for anything, and
- this gem exposes no executables.