### PR TITLE
PERF: Do not set any caching headers on preflight requests

### DIFF
--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -94,7 +94,7 @@ class MessageBus::Rack::Middleware
     end
 
     if env["REQUEST_METHOD"] == "OPTIONS"
-      return [200, headers, ["OK"]]
+      return [200, { "Content-Type" => "text/html" }, ["OK"]]
     end
 
     user_id = @bus.user_id_lookup.call(env) if @bus.user_id_lookup


### PR DESCRIPTION
This will allow each app that uses this library to handle caching
behavior of the preflight requests in a way that makes sense for their
app on their own CORS middleware.
