### PR TITLE
PERF: Optimize `Client#backlog` for up-to-date clients

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+16-02-2022
+
+- Version 4.1.0
+
+  - PERF: Optimize Client#backlog for up-to-date clients
+
+    Also introduces a new MessageBus#last_ids(*channels) api for fetching the last_ids of
+    multiple channels simultaneously
+
 11-01-2022
 
 - Version 4.0.0

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -512,7 +512,12 @@ module MessageBus::Implementation
   def last_ids(*channels, site_id: nil)
     encoded_channel_names = channels.map { |c| encode_channel_name(c, site_id) }
     ids = backend_instance.last_ids(*encoded_channel_names)
-    channels.zip(ids).to_h
+
+    result = {}
+    channels.each_with_index do |channel, index|
+      result[channel] = ids[index]
+    end
+    result
   end
 
   # Get the last message published on a channel

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -503,6 +503,18 @@ module MessageBus::Implementation
     backend_instance.last_id(encode_channel_name(channel, site_id))
   end
 
+  # Get the ID of the last message published on multiple channels
+  #
+  # @param [Array<String>] channels - array of channels to fetch
+  # @param [String] site_id - the ID of the site by which to filter
+  #
+  # @return [Array<Integer>] the channel-specific IDs of the last message published to each requested channel
+  def last_ids(*channels, site_id: nil)
+    encoded_channel_names = channels.map { |c| encode_channel_name(c, site_id) }
+    ids = backend_instance.last_ids(*encoded_channel_names)
+    channels.zip(ids).to_h
+  end
+
   # Get the last message published on a channel
   #
   # @param [String] channel the name of the channel in question

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -508,7 +508,7 @@ module MessageBus::Implementation
   # @param [Array<String>] channels - array of channels to fetch
   # @param [String] site_id - the ID of the site by which to filter
   #
-  # @return [Array<Integer>] the channel-specific IDs of the last message published to each requested channel
+  # @return [Hash] the channel-specific IDs of the last message published to each requested channel
   def last_ids(*channels, site_id: nil)
     encoded_channel_names = channels.map { |c| encode_channel_name(c, site_id) }
     ids = backend_instance.last_ids(*encoded_channel_names)

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -512,12 +512,7 @@ module MessageBus::Implementation
   def last_ids(*channels, site_id: nil)
     encoded_channel_names = channels.map { |c| encode_channel_name(c, site_id) }
     ids = backend_instance.last_ids(*encoded_channel_names)
-
-    result = {}
-    channels.each_with_index do |channel, index|
-      result[channel] = ids[index]
-    end
-    result
+    channels.zip(ids).to_h
   end
 
   # Get the last message published on a channel

--- a/lib/message_bus/backends/base.rb
+++ b/lib/message_bus/backends/base.rb
@@ -118,6 +118,15 @@ module MessageBus
         raise ConcreteClassMustImplementError
       end
 
+      # Get the ID of the last message published on multiple channels
+      #
+      # @param [Array<String>] channels - array of channels to fetch
+      #
+      # @return [Array<Integer>] the channel-specific IDs of the last message published to each requested channel
+      def last_ids(*channels)
+        raise ConcreteClassMustImplementError
+      end
+
       # Get messages from a channel backlog
       #
       # @param [String] channel the name of the channel in question

--- a/lib/message_bus/backends/memory.rb
+++ b/lib/message_bus/backends/memory.rb
@@ -244,6 +244,13 @@ module MessageBus
         client.max_id(channel)
       end
 
+      # (see Base#last_ids)
+      def last_ids(*channels)
+        channels.map do |c|
+          last_id(c)
+        end
+      end
+
       # (see Base#backlog)
       def backlog(channel, last_id = 0)
         items = client.backlog channel, last_id.to_i

--- a/lib/message_bus/backends/redis.rb
+++ b/lib/message_bus/backends/redis.rb
@@ -194,6 +194,13 @@ LUA
         pub_redis.get(backlog_id_key).to_i
       end
 
+      # (see Base#last_ids)
+      def last_ids(*channels)
+        return [] if channels.size == 0
+        backlog_id_keys = channels.map { |c| backlog_id_key(c) }
+        pub_redis.mget(*backlog_id_keys).map(&:to_i)
+      end
+
       # (see Base#backlog)
       def backlog(channel, last_id = 0)
         redis = pub_redis

--- a/lib/message_bus/version.rb
+++ b/lib/message_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessageBus
-  VERSION = "4.0.0"
+  VERSION = "4.1.0"
 end

--- a/spec/lib/message_bus/backend_spec.rb
+++ b/spec/lib/message_bus/backend_spec.rb
@@ -91,6 +91,22 @@ describe BACKEND_CLASS do
     @bus.last_id("/foo").must_equal 1
   end
 
+  it "should allow us to get multiple last_ids" do
+    @bus.last_ids("/foo", "/bar", "/foobar").must_equal [0, 0, 0]
+
+    @bus.publish("/foo", "one")
+    @bus.publish("/foo", "two")
+    @bus.publish("/foobar", "three")
+
+    @bus.last_ids("/foo", "/bar", "/foobar").must_equal(
+      [
+        @bus.last_id("/foo"),
+        @bus.last_id("/bar"),
+        @bus.last_id("/foobar")
+      ]
+    )
+  end
+
   it "can set backlog age" do
     @bus.max_backlog_age = 1
 

--- a/spec/performance/backlog.rb
+++ b/spec/performance/backlog.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '..', '..', 'lib')
+require 'logger'
+require 'benchmark'
+require 'message_bus'
+
+require_relative "../helpers"
+
+backends = ENV['MESSAGE_BUS_BACKENDS'].split(",").map(&:to_sym)
+channel = "/foo"
+iterations = 10_000
+results = []
+
+puts "Running backlog benchmark with #{iterations} iterations on backends: #{backends.inspect}"
+
+run_benchmark = lambda do |bm, backend|
+  bus = MessageBus::Instance.new
+  bus.configure(test_config_for_backend(backend))
+
+  bus.backend_instance.max_backlog_size = 100
+  bus.backend_instance.max_global_backlog_size = 1000
+
+  channel_names = 10.times.map { |i| "channel#{i}" }
+
+  100.times do |i|
+    channel_names.each do |ch|
+      bus.publish(ch, { message_number_is: i })
+    end
+  end
+
+  last_ids = channel_names.map { |ch| [ch, bus.last_id(ch)] }.to_h
+
+  1000.times do
+    # Warmup
+    client = MessageBus::Client.new(message_bus: bus)
+    channel_names.each { |ch| client.subscribe(ch, -1) }
+    client.backlog
+  end
+
+  bm.report("#{backend} - #backlog with no backlogs requested") do
+    iterations.times do
+      client = MessageBus::Client.new(message_bus: bus)
+      channel_names.each { |ch| client.subscribe(ch, -1) }
+      client.backlog
+    end
+  end
+
+  (0..5).each do |ch_i|
+    channels_with_messages = (ch_i) * 2
+
+    bm.report("#{backend} - #backlog when #{channels_with_messages}/10 channels have new messages") do
+      iterations.times do
+        client = MessageBus::Client.new(message_bus: bus)
+        channel_names.each_with_index do |ch, i|
+          client.subscribe(ch, last_ids[ch] + ((i < channels_with_messages) ? -1 : 0))
+        end
+        result = client.backlog
+        if result.length != channels_with_messages
+          raise "Result has #{result.length} messages. Expected #{channels_with_messages}"
+        end
+      end
+    end
+  end
+
+  bus.reset!
+  bus.destroy
+end
+
+puts
+
+Benchmark.benchmark("     duration\n", 60, "%10.2rs\n", "") do |bm|
+  backends.each do |backend|
+    run_benchmark.call(bm, backend)
+  end
+end
+puts
+results.each do |result|
+  puts result
+end


### PR DESCRIPTION
`Client#backlog` is most commonly used by the HTTP server. In long-polling mode clients send the id of the last message they received on each channel. They are then given the 'backlog' of more recent messages, and are subscribed to any further messages for the rest of the HTTP poll. In the vast majority of cases, there are no new messages available immediately, so the backlog is empty.

Previously, `Client#backlog` would make a separate `MessageBus#backlog` call for every subscribed channel. Under some circumstances it would make further calls to `MessageBus#last_id` for each channel. These calls scale linearly with the number of channels a user is subscribed to.

This commit refactors `Client#backlog` so that it starts by making a request to the backend for the 'last_ids' of all requested channels. Using this information, it can decide whether there is any need to call the more expensive `MessageBus#backlog` method. In most cases, there is no need.

A new `last_ids(*channels)` method is introduced which allows fetching multiple `last_id` values simultaneously. Implementations for all three backends have been added. Redis uses `MGET`, Postgres uses a single SELECT call, and the Memory backend leans on the existing #last_id method.

`spec/performance/backlog.rb` was written to test this change. On a machine with local redis/postgres, it is up to 8x faster for the (arguably most common) case where the client is already up-to-date. It becomes slightly slower once > 8 channels have backlogged messages.

Given the reduced number of round-trips, improvements may be even greater in a production environment with a remote database.

---

Time taken to process 10,000 backlog calls for a client subscribed to 10 channels. Before and after this commit:

Redis:
```
                                                            (before)   (after)
redis - #backlog with no backlogs requested                  2.53 s    0.63 s
redis - #backlog when 0/10 channels have new messages        5.05 s    0.62 s
redis - #backlog when 2/10 channels have new messages        4.79 s    1.31 s
redis - #backlog when 4/10 channels have new messages        4.47 s    2.06 s
redis - #backlog when 6/10 channels have new messages        4.16 s    2.68 s
redis - #backlog when 8/10 channels have new messages        3.84 s    3.35 s
redis - #backlog when 10/10 channels have new messages       3.47 s    4.04 s
```

Postgres:
```
                                                           (before)   (after)
postgres - #backlog with no backlogs requested               2.21 s    1.75 s
postgres - #backlog when 0/10 channels have new messages     5.38 s    1.73 s
postgres - #backlog when 2/10 channels have new messages     5.05 s    2.24 s
postgres - #backlog when 4/10 channels have new messages     4.71 s    2.70 s
postgres - #backlog when 6/10 channels have new messages     4.41 s    3.14 s
postgres - #backlog when 8/10 channels have new messages     4.04 s    3.59 s
postgres - #backlog when 10/10 channels have new messages    3.68 s    4.05 s
```