### PR TITLE
FEATURE: Add support for `clear_every` parameter in Redis backend

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+22-02-2022
+
+- Version 4.2.0
+
+  - FEATURE: Add support for `clear_every` parameter in Redis backend
+
+    This allows the clearing of the backlog to take place once every N messages. In high-load scenarios, this can provide significant performance benefit.
+
 16-02-2022
 
 - Version 4.1.0

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ message_bus also supports an in-memory backend. This can be used for testing or 
 MessageBus.configure(backend: :memory)
 ```
 
-The `:clear_every` option supported by the PostgreSQL backend is also supported by the in-memory backend.
+The `:clear_every` option is also supported by the in-memory backend.
 
 ### Transport codecs
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,9 @@ The redis client message_bus uses is [redis-rb](https://github.com/redis/redis-r
 
 #### Data Retention
 
-Out of the box Redis keeps track of 2000 messages in the global backlog and 1000 messages in a per-channel backlog. Per-channel backlogs get cleared automatically after 7 days of inactivity.
+Out of the box Redis keeps track of 2000 messages in the global backlog and 1000 messages in a per-channel backlog. Per-channel backlogs get
+cleared automatically after 7 days of inactivity. By default, the backlog will be pruned on every message publication. If exact backlog
+length limiting is not required, the `clear_every` parameter can be set higher to improve performance.
 
 This is configurable via accessors on the Backend instance.
 
@@ -401,6 +403,9 @@ MessageBus.backend_instance.max_global_backlog_size = 100
 
 # flush per-channel backlog after 100 seconds of inactivity
 MessageBus.backend_instance.max_backlog_age = 100
+
+# clear the backlog every 50 messages
+MessageBus.backend_instance.clear_every = 50
 ```
 
 ### PostgreSQL
@@ -423,7 +428,7 @@ message_bus also supports an in-memory backend. This can be used for testing or 
 MessageBus.configure(backend: :memory)
 ```
 
-The `:clear_every` option is also supported by the in-memory backend.
+The `:clear_every` option is supported in the same way as the PostgreSQL backend.
 
 ### Transport codecs
 

--- a/lib/message_bus/version.rb
+++ b/lib/message_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessageBus
-  VERSION = "4.1.0"
+  VERSION = "4.2.0"
 end

--- a/spec/lib/message_bus/backend_spec.rb
+++ b/spec/lib/message_bus/backend_spec.rb
@@ -310,8 +310,6 @@ describe BACKEND_CLASS do
   end
 
   it "should support clear_every setting" do
-    test_never :redis
-
     @bus.clear_every = 5
     @bus.max_global_backlog_size = 2
     @bus.publish "/foo", "11"

--- a/spec/performance/publish.rb
+++ b/spec/performance/publish.rb
@@ -9,7 +9,7 @@ require_relative "../helpers"
 
 backends = ENV['MESSAGE_BUS_BACKENDS'].split(",").map(&:to_sym)
 channel = "/foo"
-iterations = 10_000
+iterations = 100_000
 results = []
 
 puts "Running publication benchmark with #{iterations} iterations on backends: #{backends.inspect}"
@@ -78,6 +78,33 @@ benchmark_subscription_with_trimming = lambda do |bm, backend|
   bus.destroy
 end
 
+benchmark_subscription_with_trimming_and_clear_every = lambda do |bm, backend|
+  test_title = "#{backend} - subscription with trimming and clear_every=50"
+
+  bus = MessageBus::Instance.new
+  bus.configure(test_config_for_backend(backend))
+
+  bus.backend_instance.max_backlog_size = (iterations / 10)
+  bus.backend_instance.max_global_backlog_size = (iterations / 10)
+  bus.backend_instance.clear_every = 50
+
+  messages_received = 0
+  bus.after_fork
+  bus.subscribe(channel) do |_message|
+    messages_received += 1
+  end
+
+  bm.report(test_title) do
+    iterations.times { bus.publish(channel, "Hello world") }
+    wait_for(60000) { messages_received == iterations }
+  end
+
+  results << "[#{test_title}]: #{iterations} messages sent, #{messages_received} received, rate of #{(messages_received.to_f / iterations.to_f) * 100}%"
+
+  bus.reset!
+  bus.destroy
+end
+
 puts
 Benchmark.bm(60) do |bm|
   backends.each do |backend|
@@ -95,6 +122,10 @@ Benchmark.bm(60) do |bm|
 
   backends.each do |backend|
     benchmark_subscription_with_trimming.call(bm, backend)
+  end
+
+  backends.each do |backend|
+    benchmark_subscription_with_trimming_and_clear_every.call(bm, backend)
   end
 end
 puts


### PR DESCRIPTION
This allows the clearing of the backlog to take place once every N messages. In high-load scenarios, this can provide significant performance benefit.