### PR TITLE
Add when the memory backend was added to CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -376,6 +376,7 @@
 
 - Version 2.0.0.beta.5
 
+- Feature: Memory backend @jeremyevans
 - Fix: JavaScript unsubscribe was not updating publicly visible MessageBus.callbacks @sam
 - Fix: When MessageBus is talking to a readonly redis buffering may cause a infinite loop @tgxworld
 


### PR DESCRIPTION
This is helpful so that external libraries that depend on the
memory backend know the minimum version they can target.