### PR TITLE
Allow publishing after turning the bus off

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ end)
 
 #### Disabling message_bus
 
-In certain cases, it is undesirable for message_bus to start up on application start, for example in a Rails application during the `db:create` rake task when using the Postgres backend (which will error trying to connect to the non-existent database to subscribe). You can invoke `MessageBus.off` before the middleware chain is loaded in order to prevent subscriptions and publications from happening; in a Rails app you might do this in an initializer based on some environment variable or some other conditional means.
+In certain cases, it is undesirable for message_bus to start up on application start, for example in a Rails application during the `db:create` rake task when using the Postgres backend (which will error trying to connect to the non-existent database to subscribe). You can invoke `MessageBus.off` before the middleware chain is loaded in order to prevent subscriptions and publications from happening; in a Rails app you might do this in an initializer based on some environment variable or some other conditional means. If you want to just disable subscribing to the bus but want to continue to allow publications to be made, you can do `MessageBus.off(disable_publish: false)`.
 
 ### Debugging
 

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -40,6 +40,7 @@ module MessageBus::Implementation
     @config = {}
     @mutex = Synchronizer.new
     @off = false
+    @off_disable_publish = false
     @destroyed = false
     @timer_thread = nil
     @subscriber_thread = nil
@@ -160,15 +161,17 @@ module MessageBus::Implementation
   end
 
   # Disables publication to the bus
+  # @param [Boolean] disable_publish Whether or not to disable publishing
   # @return [void]
-  def off
+  def off(disable_publish: true)
     @off = true
+    @off_disable_publish = disable_publish
   end
 
   # Enables publication to the bus
   # @return [void]
   def on
-    @destroyed = @off = false
+    @destroyed = @off = @off_disable_publish = false
   end
 
   # Overrides existing configuration
@@ -338,7 +341,7 @@ module MessageBus::Implementation
   # @raise [MessageBus::InvalidMessage] if attempting to put permission restrictions on a globally-published message
   # @raise [MessageBus::InvalidMessageTarget] if attempting to publish to a empty group of users
   def publish(channel, data, opts = nil)
-    return if @off
+    return if @off_disable_publish
 
     @mutex.synchronize do
       raise ::MessageBus::BusDestroyed if @destroyed

--- a/lib/message_bus.rb
+++ b/lib/message_bus.rb
@@ -667,6 +667,8 @@ module MessageBus::Implementation
   end
 
   def subscribe_impl(channel, site_id, last_id, &blk)
+    return if @off
+
     raise MessageBus::BusDestroyed if @destroyed
 
     if last_id >= 0

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -17,26 +17,6 @@ describe MessageBus do
     @bus.destroy
   end
 
-  it "can be turned off" do
-    @bus.off
-
-    @bus.off?.must_equal true
-  end
-
-  it "can call destroy multiple times" do
-    @bus.destroy
-    @bus.destroy
-    @bus.destroy
-  end
-
-  it "can be turned on after destroy" do
-    @bus.destroy
-
-    @bus.on
-
-    @bus.after_fork
-  end
-
   it "destroying immediately after `after_fork` does not lock" do
     10.times do
       @bus.on
@@ -214,6 +194,40 @@ describe MessageBus do
     @bus.publish("/chuck", "foo", max_backlog_size: 1)
 
     @bus.backlog("/chuck").map { |i| i.data }.to_a.must_equal ['foo']
+  end
+
+  it "can be turned off" do
+    @bus.off
+
+    @bus.off?.must_equal true
+
+    @bus.publish("/chuck", "norris")
+
+    @bus.backlog("/chuck").to_a.must_equal []
+  end
+
+  it "can be turned off only for subscriptions" do
+    @bus.off(disable_publish: false)
+
+    @bus.off?.must_equal true
+
+    @bus.publish("/chuck", "norris")
+
+    @bus.backlog("/chuck").map(&:data).to_a.must_equal ["norris"]
+  end
+
+  it "can call destroy multiple times" do
+    @bus.destroy
+    @bus.destroy
+    @bus.destroy
+  end
+
+  it "can be turned on after destroy" do
+    @bus.destroy
+
+    @bus.on
+
+    @bus.after_fork
   end
 
   it "allows you to look up last_message" do

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -211,19 +211,27 @@ describe MessageBus do
 
     @bus.off?.must_equal true
 
-    data = nil
+    data = []
 
     @bus.subscribe("/chuck") do |msg|
-      data = msg.data
+      data << msg.data
     end
 
     @bus.publish("/chuck", "norris")
 
-    @bus.backlog("/chuck").map(&:data).to_a.must_equal ["norris"]
+    @bus.on
 
-    sleep 2
+    @bus.subscribe("/chuck") do |msg|
+      data << msg.data
+    end
 
-    assert_nil(data)
+    @bus.publish("/chuck", "berry")
+
+    wait_for(2000) { data.length > 0 }
+
+    data.must_equal ["berry"]
+
+    @bus.backlog("/chuck").map(&:data).to_a.must_equal ["norris", "berry"]
   end
 
   it "can call destroy multiple times" do

--- a/spec/lib/message_bus_spec.rb
+++ b/spec/lib/message_bus_spec.rb
@@ -211,9 +211,19 @@ describe MessageBus do
 
     @bus.off?.must_equal true
 
+    data = nil
+
+    @bus.subscribe("/chuck") do |msg|
+      data = msg.data
+    end
+
     @bus.publish("/chuck", "norris")
 
     @bus.backlog("/chuck").map(&:data).to_a.must_equal ["norris"]
+
+    sleep 2
+
+    assert_nil(data)
   end
 
   it "can call destroy multiple times" do


### PR DESCRIPTION
Many use cases for disabling the bus only really care about the subscription side, and still need to be able to publish.

See also #185.