### PR TITLE
FIX: Ensure non-long-polling requests are always spaced out

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,4 +11,13 @@ module.exports = {
   },
   rules: {},
   ignorePatterns: ['/vendor', '/doc', '/assets/jquery-1.8.2.js'],
+  overrides: [
+    {
+      // Enable async/await in tests only
+      files: ["spec/**/*"],
+      parserOptions: {
+        ecmaVersion: 2022,
+      },
+    },
+  ],
 };

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 FUTURE
 
+06-01-2023
+
+- Version 4.2.1
+
+  - FIX: Ensure non-long-polling requests are always spaced out
+
 04-11-2022
 
 - Version 4.2.0

--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -40,7 +40,7 @@
   var pollTimeout = null;
   var totalAjaxFailures = 0;
   var totalAjaxCalls = 0;
-  var lastAjax;
+  var lastAjaxStartedAt;
 
   var isHidden = (function () {
     var prefixes = ["", "webkit", "ms", "moz"];
@@ -160,7 +160,7 @@
     var rateLimited = false;
     var rateLimitedSeconds;
 
-    lastAjax = new Date();
+    lastAjaxStartedAt = new Date();
     totalAjaxCalls += 1;
     data.__seq = totalAjaxCalls;
 
@@ -290,27 +290,39 @@
       complete: function () {
         ajaxInProgress = false;
 
-        var interval;
+        var startNextRequestAfter;
         try {
           if (rateLimited) {
-            interval = Math.max(me.minPollInterval, rateLimitedSeconds * 1000);
+            // Respect `Retry-After` header
+            startNextRequestAfter = Math.max(
+              me.minPollInterval,
+              rateLimitedSeconds * 1000
+            );
           } else if (gotData || aborted) {
-            interval = me.minPollInterval;
+            // Immediately re-poll for more data
+            startNextRequestAfter = me.minPollInterval;
           } else {
-            interval = me.callbackInterval;
+            var targetRequestInterval;
+
             if (failCount > 2) {
-              interval = interval * failCount;
+              // Linear backoff up to maxPollInterval
+              targetRequestInterval = Math.min(
+                me.callbackInterval * failCount,
+                me.maxPollInterval
+              );
             } else if (!shouldLongPoll()) {
-              interval = me.backgroundCallbackInterval;
-            }
-            if (interval > me.maxPollInterval) {
-              interval = me.maxPollInterval;
+              targetRequestInterval = me.backgroundCallbackInterval;
+            } else {
+              targetRequestInterval = me.callbackInterval;
             }
 
-            interval -= new Date() - lastAjax;
+            var elapsedSinceLastAjaxStarted = new Date() - lastAjaxStartedAt;
 
-            if (interval < 100) {
-              interval = 100;
+            startNextRequestAfter =
+              targetRequestInterval - elapsedSinceLastAjaxStarted;
+
+            if (startNextRequestAfter < 100) {
+              startNextRequestAfter = 100;
             }
           }
         } catch (e) {
@@ -328,7 +340,7 @@
           pollTimeout = setTimeout(function () {
             pollTimeout = null;
             poll();
-          }, interval);
+          }, startNextRequestAfter);
         }
 
         me.longPoll = null;
@@ -367,7 +379,9 @@
           totalAjaxFailures
       );
       console.log(
-        "Last ajax call: " + (new Date() - lastAjax) / 1000 + " seconds ago"
+        "Last ajax call: " +
+          (new Date() - lastAjaxStartedAt) / 1000 +
+          " seconds ago"
       );
     },
 

--- a/assets/message-bus.js
+++ b/assets/message-bus.js
@@ -290,6 +290,7 @@
       complete: function () {
         ajaxInProgress = false;
 
+        var inLongPollingMode = shouldLongPoll();
         var startNextRequestAfter;
         try {
           if (rateLimited) {
@@ -298,7 +299,7 @@
               me.minPollInterval,
               rateLimitedSeconds * 1000
             );
-          } else if (gotData || aborted) {
+          } else if (aborted || (inLongPollingMode && gotData)) {
             // Immediately re-poll for more data
             startNextRequestAfter = me.minPollInterval;
           } else {
@@ -310,7 +311,7 @@
                 me.callbackInterval * failCount,
                 me.maxPollInterval
               );
-            } else if (!shouldLongPoll()) {
+            } else if (!inLongPollingMode) {
               targetRequestInterval = me.backgroundCallbackInterval;
             } else {
               targetRequestInterval = me.callbackInterval;

--- a/lib/message_bus/version.rb
+++ b/lib/message_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessageBus
-  VERSION = "4.3.0"
+  VERSION = "4.3.1"
 end

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/discourse/message_bus#readme",
   "devDependencies": {
-    "eslint": "^7.27.0",
+    "eslint": "^8.31.0",
     "jasmine-browser-runner": "^0.10.0",
     "jasmine-core": "^3.10.1"
   }

--- a/spec/assets/SpecHelper.js
+++ b/spec/assets/SpecHelper.js
@@ -33,8 +33,7 @@ beforeEach(function () {
   MockedXMLHttpRequest.prototype.send              = function(){
     this.readyState = 4
     this.responseText = encodeChunks(this, spec.responseChunks);
-    this.statusText = 'OK';
-    this.status = 200;
+    this.status = spec.responseStatus;
     if (this.onprogress){ this.onprogress(); }
     this.onreadystatechange()
   }
@@ -53,8 +52,8 @@ beforeEach(function () {
     this.headers[k] = v;
   }
 
-  MockedXMLHttpRequest.prototype.getResponseHeader = function(){
-    return 'text/plain; charset=utf-8';
+  MockedXMLHttpRequest.prototype.getResponseHeader = function(headerName){
+    return spec.responseHeaders[headerName];
   }
 
   MessageBus.xhrImplementation = MockedXMLHttpRequest
@@ -64,12 +63,19 @@ beforeEach(function () {
     {channel: '/test', data: {password: 'MessageBusRocks!'}}
   ];
 
+  this.responseStatus = 200;
+  this.responseHeaders = {
+    "Content-Type": 'text/plain; charset=utf-8',
+  };
+
   MessageBus.start();
 });
 
 afterEach(function(){
   MessageBus.stop()
   MessageBus.callbacks.splice(0, MessageBus.callbacks.length)
+  MessageBus.shouldLongPollCallback = null;
+  MessageBus.enableChunkedEncoding = true;
 });
 
 window.testMB = function(description, testFn, path, data){

--- a/spec/assets/message-bus.spec.js
+++ b/spec/assets/message-bus.spec.js
@@ -1,3 +1,4 @@
+/* eslint-env es2022 */
 /* global describe, it, spyOn, MessageBus, expect, jasmine, testMB */
 
 function approxEqual(valueOne, valueTwo) {


### PR DESCRIPTION
When long-polling, after a request returns some data, message-bus will immediately begin another long-polling request to maintain a consistent stream of messages.

When not long polling, we do not expect a continuous stream of messages, and the client aims to make one request every `backgroundCallbackInterval` (default 60s).

Before this commit, some long-polling logic was leaking into the non-long-polling requests. Under certain situations (e.g. a channel receiving very frequent messages), this could cause clients to start issuing non-long-polling requests every `minPollInterval` (100ms). This commit fixes the logic so that 'immediate retry' is only performed when in long-polling mode.