### PR TITLE
FIX: Do not disable chunking on cancel/error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 FUTURE
 
+
+13-01-2023
+
+- Version 4.2.1
+
+  - FIX: Do not disable chunking on cancel/error
+
 06-01-2023
 
 - Version 4.2.1

--- a/lib/message_bus/version.rb
+++ b/lib/message_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessageBus
-  VERSION = "4.3.1"
+  VERSION = "4.3.2"
 end


### PR DESCRIPTION
If the first chunk of a message takes more than 3s, we assume an intermediate proxy is buffering data and drop into dont-chunk mode. Previously, this 3s timer would continue even if a request was aborted before the first chunk arrived (e.g. channel subscriptions change in quick succession). This commit ensures the timer is cancelled when the request is aborted.