### PR TITLE
Make headers all lowercase in rack middleware

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 FUTURE
 
-  - FIX: Use lowercase header names in `MessageBus::Rack::Middleware`
+  - FIX: Use lowercase header names in `MessageBus::Rack::Middleware` for compatibility with Rack 3.x.
 
 13-01-2023
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 FUTURE
 
+  - FIX: Use lowercase header names in `MessageBus::Rack::Middleware`
 
 13-01-2023
 

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -82,10 +82,10 @@ class MessageBus::Rack::Middleware
     return [404, {}, ["not found"]] unless client_id
 
     headers = {}
-    headers["Cache-Control"] = "must-revalidate, private, max-age=0"
-    headers["Content-Type"] = "application/json; charset=utf-8"
-    headers["Pragma"] = "no-cache"
-    headers["Expires"] = "0"
+    headers["cache-control"] = "must-revalidate, private, max-age=0"
+    headers["content-type"] = "application/json; charset=utf-8"
+    headers["pragma"] = "no-cache"
+    headers["expires"] = "0"
 
     if @bus.extra_response_headers_lookup
       @bus.extra_response_headers_lookup.call(env).each do |k, v|


### PR DESCRIPTION
Rack v3 incorporated https://github.com/rack/rack/issues/1592; using MessageBus with Rack still seems to work, but error messages like this appear in the server logs when requests come in:

```
rack_1   | Rack::Lint::LintError: uppercase character in header name: Content-Type
rack_1   |      /usr/local/bundle/gems/rack-3.0.4.1/lib/rack/lint.rb:653:in `block in check_headers'
rack_1   |      /usr/local/bundle/gems/rack-3.0.4.1/lib/rack/lint.rb:637:in `each'
rack_1   |      /usr/local/bundle/gems/rack-3.0.4.1/lib/rack/lint.rb:637:in `check_headers'
rack_1   |      /usr/local/bundle/gems/rack-3.0.4.1/lib/rack/lint.rb:73:in `response'
rack_1   |      /usr/local/bundle/gems/rack-3.0.4.1/lib/rack/lint.rb:35:in `call'
rack_1   |      /usr/local/bundle/gems/rack-3.0.4.1/lib/rack/show_exceptions.rb:27:in `call'
rack_1   |      /usr/local/bundle/gems/rack-3.0.4.1/lib/rack/common_logger.rb:43:in `call'
rack_1   |      /usr/local/bundle/gems/rack-3.0.4.1/lib/rack/chunked.rb:102:in `call'
rack_1   |      /usr/local/bundle/gems/rack-3.0.4.1/lib/rack/content_length.rb:20:in `call'
rack_1   |      /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:634:in `process_client'
rack_1   |      /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:739:in `worker_loop'
rack_1   |      /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:547:in `spawn_missing_workers'
rack_1   |      /usr/local/bundle/gems/unicorn-6.1.0/lib/unicorn/http_server.rb:143:in `start'
rack_1   |      /usr/local/bundle/gems/unicorn-6.1.0/bin/unicorn:128:in `<top (required)>'
rack_1   |      /usr/local/bundle/bin/unicorn:25:in `load'
rack_1   |      /usr/local/bundle/bin/unicorn:25:in `<main>'
```