### PR TITLE
Fix bad exclusion of messagebus configuration option in redis connection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+FUTURE
+
+- FIX: Typo in `group_ids_lookup` option name in Redis params exclusion list that was preventing the use of the redis backend along with this option.
+
 28-06-2023
 
 - Version 4.3.7

--- a/lib/message_bus/backends/redis.rb
+++ b/lib/message_bus/backends/redis.rb
@@ -364,7 +364,7 @@ LUA
             :base_route,
             :client_message_filters,
             :site_id_lookup,
-            :group_id_lookup,
+            :group_ids_lookup,
             :user_id_lookup,
             :transport_codec
           ].include?(k)


### PR DESCRIPTION
Creating just a DRAFT PR for now to get insights.

I discovered it is impossible to use the group ids lookup feature alongside the redis backend as there is a typo in the exclusion list.

As stated by the comment, we should probably allowlist the params to be passed to redis rather then exclude some known ones. Maybe even better would be to have them in a separate `redis_options` hash but this would kill backwards compatibility.

Additionally, a regression spec is needed

Any idea which direction is preferred ? 