### PR TITLE
Add :long_polling_interval to Redis config blocklist

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 28-06-2023
 
+- Version 4.3.7
+
+  - FIX: Allow using `:long_polling_interval` with Redis gem version 5+.
+
 - Version 4.3.6
 
   - Don't error when trying to write a message to a closed client take 2

--- a/lib/message_bus/backends/redis.rb
+++ b/lib/message_bus/backends/redis.rb
@@ -359,6 +359,7 @@ LUA
             :backend,
             :logger,
             :long_polling_enabled,
+            :long_polling_interval,
             :backend_options,
             :base_route,
             :client_message_filters,

--- a/lib/message_bus/version.rb
+++ b/lib/message_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessageBus
-  VERSION = "4.3.6"
+  VERSION = "4.3.7"
 end


### PR DESCRIPTION
As discussed in #330, an allowlist would be better still.

This is preventing us from upgrading to Redis 5.