### PR TITLE
Removes close_db_connection! deprecation warning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 FUTURE
 
 - FIX: Typo in `group_ids_lookup` option name in Redis params exclusion list that was preventing the use of the redis backend along with this option.
+- FIX: Removes close_db_connection! deprecation warning.
 
 28-06-2023
 

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -199,7 +199,9 @@ class MessageBus::Rack::Middleware
     # ConnectionManagement in Rails puts a BodyProxy around stuff
     #  this means connections are not returned until rack.async is
     #  closed
-    if defined? ActiveRecord::Base.clear_active_connections!
+    if defined? ActiveRecord::Base.connection_handler
+      ActiveRecord::Base.connection_handler.clear_active_connections!
+    elsif defined? ActiveRecord::Base.clear_active_connections!
       ActiveRecord::Base.clear_active_connections!
     end
   end


### PR DESCRIPTION
Method was deprecated in Rails

https://github.com/rails/rails/commit/a93d8fe29440c0791bdd71adb07b617dd8a9b33d
