### PR TITLE
FIX: Don't error when trying to write a message to a closed client

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,13 @@
-FUTURE
+19-06-2023
+
+- Version 4.3.3
 
   - FIX: Use lowercase header names in `MessageBus::Rack::Middleware` for compatibility with Rack 3.x.
+  - FIX: Don't error when trying to write a message to a closed client
 
 13-01-2023
 
-- Version 4.2.1
+- Version 4.3.2
 
   - FIX: Do not disable chunking on cancel/error
 
@@ -35,7 +38,7 @@ FUTURE
 
   - PERF: Optimize Client#backlog for up-to-date clients
 
-    Also introduces a new MessageBus#last_ids(*channels) api for fetching the last_ids of
+    Also introduces a new MessageBus#last_ids(\*channels) api for fetching the last_ids of
     multiple channels simultaneously
 
 11-01-2022

--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -278,7 +278,7 @@ class MessageBus::Client
       @async_response << data
       @async_response << postfix
       @async_response << NEWLINE
-    else
+    elsif @io
       @io.write(chunk_length.to_s(16) << NEWLINE << data << postfix << NEWLINE)
     end
   end

--- a/lib/message_bus/version.rb
+++ b/lib/message_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessageBus
-  VERSION = "4.3.2"
+  VERSION = "4.3.3"
 end

--- a/spec/lib/message_bus/client_spec.rb
+++ b/spec/lib/message_bus/client_spec.rb
@@ -99,6 +99,12 @@ describe MessageBus::Client do
       chunk2.length.must_equal 0
     end
 
+    it "does not raise an error when trying to write a message to a closed client using chunked encoding" do
+      @client.use_chunked = true
+      assert(@client.closed?)
+      @client << MessageBus::Message.new(1, 1, "/test", "test")
+    end
+
     it "does not bleed data across sites" do
       @client.site_id = "test"
 


### PR DESCRIPTION
When a client is set to use chunked encoding by setting `use_chunked` to
true, trying to write a message to the client when the client has been
closed will raise an error. This commit changes it such that we don't
raise an error since the raised error doesn't do anything useful.