### PR TITLE
Revert "FIX: Don't error when trying to write a message to a closed client (#336)"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+20-06-2023
+
+- Version 4.3.4
+
+  - Revert "FIX: Don't error when trying to write a message to a closed client (#336)".
+    This seems to have broken MessageBus in production so reverting for now.
+
 19-06-2023
 
 - Version 4.3.3

--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -278,7 +278,7 @@ class MessageBus::Client
       @async_response << data
       @async_response << postfix
       @async_response << NEWLINE
-    elsif @io
+    else
       @io.write(chunk_length.to_s(16) << NEWLINE << data << postfix << NEWLINE)
     end
   end

--- a/lib/message_bus/version.rb
+++ b/lib/message_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessageBus
-  VERSION = "4.3.3"
+  VERSION = "4.3.4"
 end

--- a/spec/lib/message_bus/client_spec.rb
+++ b/spec/lib/message_bus/client_spec.rb
@@ -99,12 +99,6 @@ describe MessageBus::Client do
       chunk2.length.must_equal 0
     end
 
-    it "does not raise an error when trying to write a message to a closed client using chunked encoding" do
-      @client.use_chunked = true
-      assert(@client.closed?)
-      @client << MessageBus::Message.new(1, 1, "/test", "test")
-    end
-
     it "does not bleed data across sites" do
       @client.site_id = "test"
 


### PR DESCRIPTION
This reverts commit a2a46fde87f4c9c6cff806db5d84c2544befaa6d.

This seems to have broken MessageBus in production so we need to revert
for now and cut a new release.