### PR TITLE
REVERT: Make headers all lowercase in rack middleware (#328)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 20-06-2023
 
+- Version 4.3.5
+
+  - Revert "Make headers all lowercase in rack middleware (#328)".
+    This seems to have broken MessageBus in production so reverting for now.
+
 - Version 4.3.4
 
   - Revert "FIX: Don't error when trying to write a message to a closed client (#336)".

--- a/lib/message_bus/rack/middleware.rb
+++ b/lib/message_bus/rack/middleware.rb
@@ -82,10 +82,10 @@ class MessageBus::Rack::Middleware
     return [404, {}, ["not found"]] unless client_id
 
     headers = {}
-    headers["cache-control"] = "must-revalidate, private, max-age=0"
-    headers["content-type"] = "application/json; charset=utf-8"
-    headers["pragma"] = "no-cache"
-    headers["expires"] = "0"
+    headers["Cache-Control"] = "must-revalidate, private, max-age=0"
+    headers["Content-Type"] = "application/json; charset=utf-8"
+    headers["Pragma"] = "no-cache"
+    headers["Expires"] = "0"
 
     if @bus.extra_response_headers_lookup
       @bus.extra_response_headers_lookup.call(env).each do |k, v|

--- a/lib/message_bus/version.rb
+++ b/lib/message_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessageBus
-  VERSION = "4.3.4"
+  VERSION = "4.3.5"
 end


### PR DESCRIPTION
This seems to have broken MessageBus in production so reverting for now.