### PR TITLE
Don't error when trying to write a message to a closed client take 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+28-06-2023
+
+- Version 4.3.6
+
+  - Don't error when trying to write a message to a closed client take 2
+
 20-06-2023
 
 - Version 4.3.5

--- a/lib/message_bus/client.rb
+++ b/lib/message_bus/client.rb
@@ -278,7 +278,7 @@ class MessageBus::Client
       @async_response << data
       @async_response << postfix
       @async_response << NEWLINE
-    else
+    elsif @io
       @io.write(chunk_length.to_s(16) << NEWLINE << data << postfix << NEWLINE)
     end
   end

--- a/lib/message_bus/version.rb
+++ b/lib/message_bus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MessageBus
-  VERSION = "4.3.5"
+  VERSION = "4.3.6"
 end

--- a/spec/lib/message_bus/client_spec.rb
+++ b/spec/lib/message_bus/client_spec.rb
@@ -99,6 +99,12 @@ describe MessageBus::Client do
       chunk2.length.must_equal 0
     end
 
+    it "does not raise an error when trying to write a message to a closed client using chunked encoding" do
+      @client.use_chunked = true
+      assert(@client.closed?)
+      @client << MessageBus::Message.new(1, 1, "/test", "test")
+    end
+
     it "does not bleed data across sites" do
       @client.site_id = "test"
 


### PR DESCRIPTION
This was first introduced in a2a46fde87f4c9c6cff806db5d84c2544befaa6d
but reverted because a new MessageBus release broke production and we
had to quickly revert before being able to isolate the commit. We have
since tested this commit in isolation in production and confirm that
MessageBus continues to work.

When a client is set to use chunked encoding by setting `use_chunked` to
true, trying to write a message to the client when the client has been
closed will raise an error. This commit changes it such that we don't
raise an error since the raised error doesn't do anything useful.
