### PR TITLE
DOC: Fix CHANGELOG version numbering for 4.3.0 and 4.3.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,13 +42,13 @@
 
 06-01-2023
 
-- Version 4.2.1
+- Version 4.3.1
 
   - FIX: Ensure non-long-polling requests are always spaced out
 
 04-11-2022
 
-- Version 4.2.0
+- Version 4.3.0
 
   - FIX: Add redis gem version 5 support
   - FEATURE: Allow disabling subscriptions without disabling publication


### PR DESCRIPTION
It looks like 4.3.0 and 4.3.1 were wrongly labeled as 4.2.0 and 4.2.1 respectively in CHANGELOG file.

It can be confusing, eg I thought that it's enough to update to 4.2.0 to have redis gem ver 5 support.