### PR TITLE
Add logger as a dependency

### DIFF
--- a/message_bus.gemspec
+++ b/message_bus.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.6.0"
 
   gem.add_runtime_dependency 'rack', '>= 1.1.3'
+  gem.add_runtime_dependency 'logger'
 
   # Optional runtime dependencies
   gem.add_development_dependency 'redis'


### PR DESCRIPTION
Not having it as a dependency when using bundler warns in Ruby 3.4 and will fail in Ruby 3.5 unless some other gem in the bundle depends on it.

An alternative approach would be to remove the internal use of logger.